### PR TITLE
remove roots from database function created, messages created + function added to cli

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,3 @@
 from .create import create_project
 from .open import open_project
-from .roots_management import add_project
+from .roots_management import add_project, remove_project

--- a/app/roots_management/__init__.py
+++ b/app/roots_management/__init__.py
@@ -1,1 +1,2 @@
 from .add import add_project
+from .remove import remove_project

--- a/app/roots_management/remove.py
+++ b/app/roots_management/remove.py
@@ -1,0 +1,39 @@
+from utils import json, select_project_root, remove_messages as get_message
+
+
+def remove_project(projects_root, db_path):
+    selected_project_root = select_project_root(projects_root)
+    execute_project(selected_project_root, db_path)
+
+
+def execute_project(selected_project_root, db_path):
+    confirmation = (
+        input(get_message("input_confirmation_message", selected_project_root.name))
+        .strip()
+        .lower()
+    )
+
+    if confirmation == "y" or confirmation == "":
+        with open(db_path, "r") as f:
+            projects_data = json.load(f)
+
+        index_to_remove = None
+        for index, project in enumerate(projects_data):
+            if project["id"] == selected_project_root.id:
+                index_to_remove = index
+                break
+
+        if index_to_remove is not None:
+            del projects_data[index_to_remove]
+            print(get_message("Project_removed_message", selected_project_root.name))
+        else:
+            print(get_message("project_not_found_message", selected_project_root.name))
+
+        with open(db_path, "w") as f:
+            json.dump(projects_data, f, indent=4)
+    else:
+        print(get_message("canel_remove_message"))
+
+
+if __name__ == "__main__":
+    remove_project()

--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,4 @@
-from app import open_project, create_project, add_project
+from app import open_project, create_project, add_project, remove_project
 from utils import load_db, db_path
 import sys
 
@@ -12,6 +12,7 @@ Commands:
   -c, --create    Create a new project
   -o, --open      Open an existing project
   -a, --add       Add new projects directory
+  -r, --remove    remove projects directory
   -h, --help      Show this help message
 """
     )
@@ -32,6 +33,8 @@ def main():
             open_project(load_db())
         elif command in ["-a", "--add"]:
             add_project(load_db(), db_path)
+        elif command in ["-r", "--remove"]:
+            remove_project(load_db(), db_path)
         else:
             print("Invalid command. Use '-h' or '--help' for usage instructions.")
             show_help()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -9,4 +9,4 @@ from .common import (
     db_path,
 )
 
-from .messages import open_messages, add_messages, create_messages
+from .messages import open_messages, add_messages, create_messages, remove_messages

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -60,3 +60,24 @@ def open_messages(message_type, project_name=None, selected_project_root=None):
             return messages[message_type]
     else:
         return "Invalid message type"
+
+
+def remove_messages(message_type, project_root_name=None):
+    messages = {
+        "input_confirmation_message": "Are you sure you want to remove '{project_root_name}' from the database? [Y/n] ",
+        "Project_removed_message": "Project {project_root_name} removed from db.",
+        "project_not_found_message": "Project {project_root_name} not found.",
+        "canel_remove_message": "Removal canceled.",
+    }
+
+    if message_type in messages:
+        if (
+            message_type == "input_confirmation_message"
+            or message_type == "Project_removed_message"
+            or message_type == "project_not_found_message"
+        ):
+            return messages[message_type].format(project_root_name=project_root_name)
+        else:
+            return messages[message_type]
+    else:
+        return "Invalid message type"


### PR DESCRIPTION
Added 'feature delete' to remove roots from the database

Implemented a remove function feature to enable the removal of roots from the database. This feature includes:
- Creation of the remove function
- Implementation of a set of messages
- Addition of the '-r' command to the CLI file

Included the 'remove_project' function which:
- Selects the project root
- Executes the project removal process
- Prompts for confirmation before deletion
- Removes the specified project from the database if confirmed
- Provides appropriate messages for successful removal, project not found, or cancellation

The 'execute_project' function handles the execution of the removal process by:
- Loading project data from the database
- Identifying the index of the project to remove
- Deleting the project from the database
- Writing the updated project data back to the database

This commit enhances the functionality by providing a way to remove projects from the database.