### PR TITLE
edit roots and name from database function created, messages created + function added to cli

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,3 @@
 from .create import create_project
 from .open import open_project
-from .roots_management import add_project, remove_project
+from .roots_management import add_project, remove_project, edit_project

--- a/app/roots_management/__init__.py
+++ b/app/roots_management/__init__.py
@@ -1,2 +1,3 @@
 from .add import add_project
 from .remove import remove_project
+from .edit import edit_project

--- a/app/roots_management/edit.py
+++ b/app/roots_management/edit.py
@@ -1,0 +1,61 @@
+from utils import os, json, select_project_root, edit_messages as get_message
+
+
+def edit_project(projects_root, db_path):
+    selected_project_root = select_project_root(projects_root)
+
+    while True:
+        print(get_message("make_a_choice_message"))
+        choice = input().strip().lower()
+
+        if choice == "n":
+            selected_project_root.name = validate_projects_root_name(projects_root)
+            print(get_message("success_modif_name_message", selected_project_root.name))
+            break
+        elif choice == "p":
+            selected_project_root.path = validate_projects_root_path(projects_root)
+            print(get_message("success_modif_path_message", selected_project_root.name))
+            break
+        else:
+            print(get_message("invalid_choice_message"))
+
+    update_project_db(projects_root, db_path, selected_project_root)
+
+
+def validate_projects_root_name(projects):
+    while True:
+        new_name = input(get_message("input_new_name_message")).strip()
+        if new_name not in [project.name for project in projects]:
+            return new_name
+        else:
+            print(get_message("error_project_exists_message"))
+
+
+def validate_projects_root_path(projects):
+    while True:
+        new_root = input(get_message("input_new_path_message")).strip()
+        if os.path.isdir(new_root):
+            if new_root not in [project.path for project in projects]:
+                return new_root
+            else:
+                print(get_message("error_path_exists_message"))
+        else:
+            print(get_message("error_invalid_path_message"))
+
+
+def update_project_db(projects_root, db_path, selected_project_root):
+    with open(db_path, "r") as f:
+        projects_data = json.load(f)
+
+    for project in projects_data:
+        if project["id"] == selected_project_root.id:
+            project["name"] = selected_project_root.name
+            project["path"] = selected_project_root.path
+            break
+
+    with open(db_path, "w") as f:
+        json.dump(projects_data, f, indent=4)
+
+
+if __name__ == "__main__":
+    edit_project()

--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,4 @@
-from app import open_project, create_project, add_project, remove_project
+from app import open_project, create_project, add_project, remove_project, edit_project
 from utils import load_db, db_path
 import sys
 
@@ -12,6 +12,7 @@ Commands:
   -c, --create    Create a new project
   -o, --open      Open an existing project
   -a, --add       Add new projects directory
+  -e, --edit      edit projects directory
   -r, --remove    remove projects directory
   -h, --help      Show this help message
 """
@@ -33,6 +34,8 @@ def main():
             open_project(load_db())
         elif command in ["-a", "--add"]:
             add_project(load_db(), db_path)
+        elif command in ["-e", "--edit"]:
+            edit_project(load_db(), db_path)
         elif command in ["-r", "--remove"]:
             remove_project(load_db(), db_path)
         else:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -9,4 +9,10 @@ from .common import (
     db_path,
 )
 
-from .messages import open_messages, add_messages, create_messages, remove_messages
+from .messages import (
+    open_messages,
+    add_messages,
+    create_messages,
+    remove_messages,
+    edit_messages,
+)

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -81,3 +81,28 @@ def remove_messages(message_type, project_root_name=None):
             return messages[message_type]
     else:
         return "Invalid message type"
+
+
+def edit_messages(message_type, project_root_name=None):
+    messages = {
+        "make_a_choice_message": "Do you want to edit project's name 'n' or path 'p' ?",
+        "invalid_choice_message": "Invalid choice. Please enter 'n' to edit name or 'r' to edit root.",
+        "input_new_name_message": "Enter the new name: ",
+        "error_project_exists_message": "Error: The specified project name already exists in the database. Please enter a unique name.",
+        "input_new_path_message": "Enter the new path: ",
+        "error_path_exists_message": "Error: The specified directory path already exists in the database.",
+        "error_invalid_path_message": "Error: The specified directory does not exist. Please enter a valid directory path.",
+        "success_modif_name_message": "Name '{project_root_name}' modified successfully!",
+        "success_modif_path_message": "Path '{project_root_name}' modified successfully!",
+    }
+
+    if message_type in messages:
+        if (
+            message_type == "success_modif_name_message"
+            or message_type == "success_modif_path_message"
+        ):
+            return messages[message_type].format(project_root_name=project_root_name)
+        else:
+            return messages[message_type]
+    else:
+        return "Invalid message type"


### PR DESCRIPTION
Added 'feature edit' for modifying projects root details

Implemented an edit function feature to enable modification of projects root details in the database. This feature includes:
- Creation of the edit function
- Implementation of a set of messages
- Providing options to modify projects root name or path

The 'edit_project' function allows users to:
- Select a projects root to edit
- Choose between modifying the projects root name or path
- Validate and update the selected details
- Update the projects root database with the modified details

Additional functions include:
- 'validate_projects_root_name': Validates and returns a new name for the projects root
- 'validate_projects_root_path': Validates and returns a new path for the projects root

The 'update_project_db' function updates the project database with the modified projects root details.

In the CLI file:
- Added command line options '-e' and '--edit' to trigger the edit feature

This commit enhances the functionality by providing a way to edit and update projects root details in the database, accessible via the command line interface.

